### PR TITLE
GH-1 Add basic issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,26 @@
+---
+name: Bug
+about: Report something that is not working as expected
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+Add a clear and concise description of what the bug is.
+
+**To reproduce**
+Describe the steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+**Expected behavior**
+Describe what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain the problem.
+
+**Additional context**
+Add any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,16 @@
+---
+name: Feature
+about: Suggest an enhancement for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**What**
+Add a clear and concise description of what you want to happen.
+
+**Why**
+Add a motivation for this feature request.
+
+**Additional context**
+Add any other context about the feature request.

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -1,0 +1,22 @@
+---
+name: Research
+about: Look into an idea or topic related to this project
+title: ''
+labels: research
+assignees: ''
+---
+
+**What**
+Add a clear and concise description of the topic to do research on.
+
+**Why**
+Add a reason for why we need to do research on this topic.
+
+**Scope**
+Define the scope of the research. What should or should not be included.
+
+**Result**
+Add suggestions on how to document the results of the research.
+
+**Additional context**
+Any other context or references for this topic.


### PR DESCRIPTION
Implements #1 by adding templates for bugs, feature requests, and research issues.

The templates have been created from the GitHub Repository Settings UI, as described in the [GitHub documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates). The files were then adapted locally.

I did not add a "process" template, as these issues will be rare, and very custom by nature.